### PR TITLE
poolmaster support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,51 @@ gathered by this exporter.
 ![Grafana dashboard sample 1](https://grafana.com/api/dashboards/16588/images/12479/image)
 ![Grafana dashboard sample 2](https://grafana.com/api/dashboards/16588/images/12482/image)
 
+
+
+# Example setup for a XenServer cluster
+
+docker-compose.yml
+
+```
+version: '2.4'
+services:
+  xen01:
+    container_name: xen01
+    image: ghcr.io/mikedombo/xen-exporter:latest
+    environment:
+      - XEN_HOST=10.10.10.101
+      - XEN_USER=root
+      - XEN_PASSWORD=s0m3f4ncyp4ssw0rd
+      - XEN_SSL_VERIFY=false
+
+  xen02:
+    container_name: xen02
+    image: ghcr.io/mikedombo/xen-exporter:latest
+    environment:
+      - XEN_HOST=10.10.10.102
+      - XEN_USER=root
+      - XEN_PASSWORD=s0m3f4ncyp4ssw0rd
+      - XEN_SSL_VERIFY=false
+```
+
+prometheus.yml
+
+```
+  - job_name: xenserver
+    scrape_interval: 60s
+    scrape_timeout: 50s
+    static_configs:
+    - targets:
+      - xen01:9100
+      - xen02:9100
+```
+
 # Limitations
 
 No Prometheus help (comments) or types are currently emitted since all the metrics are being formatted almost entirely automatically.
 Meaning that there is no list in the code of what metrics will be emitted, nor is there a list of nice descriptions for each metric type.
+When using a cluster, assumes that the username and password of the poolmaster and hosts are the same.
 
 # TODO
 - Proper Prometheus help and types for known metrics

--- a/xen-exporter.py
+++ b/xen-exporter.py
@@ -25,8 +25,8 @@ def lookup_vm_name(vm_uuid, session):
 def lookup_sr_name_by_uuid(sr_uuid, session):
     try:
        return session.xenapi.SR.get_name_label(session.xenapi.SR.get_by_uuid(sr_uuid))
-    except:
-       print("")
+    except XenAPI.XenAPI.Failure:
+       return sr_uuid
 
 
 def lookup_host_name(host_uuid, session):

--- a/xen-exporter.py
+++ b/xen-exporter.py
@@ -23,7 +23,10 @@ def lookup_vm_name(vm_uuid, session):
 
 
 def lookup_sr_name_by_uuid(sr_uuid, session):
-    return session.xenapi.SR.get_name_label(session.xenapi.SR.get_by_uuid(sr_uuid))
+    try:
+       return session.xenapi.SR.get_name_label(session.xenapi.SR.get_by_uuid(sr_uuid))
+    except:
+       print("")
 
 
 def lookup_host_name(host_uuid, session):

--- a/xen-exporter.py
+++ b/xen-exporter.py
@@ -4,6 +4,7 @@ import urllib.request
 import time
 import ssl
 import os
+import re
 
 import pyjson5
 import XenAPI
@@ -62,6 +63,19 @@ def get_or_set(d, key, func, *args):
         d[key] = func(key, *args)
     return d[key]
 
+def collect_poolmaster():
+    xen_user = os.getenv("XEN_USER", "root")
+    xen_password = os.getenv("XEN_PASSWORD", "")
+    xen_host = os.getenv("XEN_HOST", "localhost")
+    verify_ssl = "false"
+    verify_ssl = True if verify_ssl.lower() == "true" else False
+    try:
+       with Xen("https://" + xen_host, xen_user, xen_password, verify_ssl) as xen:
+          poolmaster = xen_host
+    except XenAPI.XenAPI.Failure as e:
+       ipPattern = re.compile('\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}')
+       poolmaster = re.findall(ipPattern,str(e))[0]
+    return poolmaster
 
 class Xen:
     def __init__(self, url, username, password, verify_ssl):
@@ -106,9 +120,10 @@ def collect_metrics():
     verify_ssl = os.getenv("XEN_SSL_VERIFY", "true")
     verify_ssl = True if verify_ssl.lower() == "true" else False
 
+    xen_poolmaster = collect_poolmaster()
     collector_start_time = time.perf_counter()
 
-    with Xen("https://" + xen_host, xen_user, xen_password, verify_ssl) as xen:
+    with Xen("https://" + xen_poolmaster, xen_user, xen_password, verify_ssl) as xen:
         url = f"https://{xen_host}/rrd_updates?start={int(time.time()-10)}&json=true&host=true&cf=AVERAGE"
 
         req = urllib.request.Request(url)


### PR DESCRIPTION
According to: https://xapi-project.github.io/xen-api/metrics.html

_RRDs are resident on the server on which the VM is running, or the pool master when the VM is not running._
However, we need the poolmaster to decode the UUID's.

This commit adds functionatlity to find the poolmaster IP, so that the api connection always goes to the poolmaster.
When not in a cluster, the single host is the "poolmaster".

RRD files are downloaded from the host directly. 

Tested the build in my own fork, and works perfectly.
(if you want, you can test solipsist01/xen-exporter)

Thank you for your work on this exporter. We're loving it!