### PR TITLE
Some short_sr are not present in uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Automatically exports _all_ statistics from the [RRD metrics database](https://x
 # Usage
 
 ```cmd
-docker run -e XEN_USER=root -e XEN_PASSWORD=<password> -e XEN_HOST=<host> -e XEN_SSL_VERIFY=true HALT_ON_NO_UUID=false -p 9100:9100 --rm ghcr.io/mikedombo/xen-exporter:latest
+docker run -e XEN_USER=root -e XEN_PASSWORD=<password> -e XEN_HOST=<host> -e XEN_SSL_VERIFY=true -p 9100:9100 --rm ghcr.io/mikedombo/xen-exporter:latest
 ```
 
 > HALT_ON_NO_UUID - optional, false by default. Ignores metrics with no UUID

--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ Automatically exports _all_ statistics from the [RRD metrics database](https://x
 # Usage
 
 ```cmd
-docker run -e XEN_USER=root -e XEN_PASSWORD=<password> -e XEN_HOST=<host> -e XEN_SSL_VERIFY=true -p 9100:9100 --rm ghcr.io/mikedombo/xen-exporter:latest
+docker run -e XEN_USER=root -e XEN_PASSWORD=<password> -e XEN_HOST=<host> -e XEN_SSL_VERIFY=true HALT_ON_NO_UUID=false -p 9100:9100 --rm ghcr.io/mikedombo/xen-exporter:latest
 ```
+
+> HALT_ON_NO_UUID - optional, false by default. Ignores metrics with no UUID
 
 # Grafana
 A Grafana dashboard is [available here](https://grafana.com/grafana/dashboards/16588) (id 16588), which graphs most of the critical metrics

--- a/xen-exporter.py
+++ b/xen-exporter.py
@@ -177,7 +177,7 @@ def collect_metrics():
             ):
                 short_sr = metric_type.split("_")[-1]
                 long_sr = find_full_sr_uuid(short_sr, xen, halt_on_no_uuid)
-                if(long_sr is not None): ## 
+                if long_sr is not None:
                     sr = get_or_set(srs, long_sr, lookup_sr_name_by_uuid, xen)
                     extra_tags["sr"] = sr
                     extra_tags["sr_uuid"] = long_sr

--- a/xen-exporter.py
+++ b/xen-exporter.py
@@ -58,7 +58,7 @@ def find_full_sr_uuid(beginning_uuid, xen, halt_on_no_uuid):
             )
         uuid = uuid[0]
         return uuid
-    if(halt_on_no_uuid): raise Exception(f"Found no SRs with starting with UUID {beginning_uuid}")
+    if halt_on_no_uuid: raise Exception(f"Found no SRs starting with UUID {beginning_uuid}")
 
 
 def get_or_set(d, key, func, *args):

--- a/xen-exporter.py
+++ b/xen-exporter.py
@@ -39,7 +39,7 @@ def lookup_sr_uuid_by_ref(sr_ref, session):
     return session.xenapi.SR.get_uuid(sr_ref)
 
 
-def find_full_sr_uuid(beginning_uuid, xen):
+def find_full_sr_uuid(beginning_uuid, xen, halt_on_no_uuid):
     for i in range(0, 2):
         uuid = list(filter(lambda x: x.startswith(beginning_uuid), all_srs))
         if len(uuid) == 0:
@@ -54,11 +54,11 @@ def find_full_sr_uuid(beginning_uuid, xen):
             continue  # skip the rest of the loop and try the search again
         elif len(uuid) > 1:
             raise Exception(
-                f"Found multiple SRs with starting with UUID {beginning_uuid}"
+                f"Found multiple SRs starting with UUID {beginning_uuid}"
             )
         uuid = uuid[0]
         return uuid
-    raise Exception(f"Found no SRs with starting with UUID {beginning_uuid}")
+    if(halt_on_no_uuid): raise Exception(f"Found no SRs with starting with UUID {beginning_uuid}")
 
 
 def get_or_set(d, key, func, *args):
@@ -123,6 +123,9 @@ def collect_metrics():
     verify_ssl = os.getenv("XEN_SSL_VERIFY", "true")
     verify_ssl = True if verify_ssl.lower() == "true" else False
 
+    halt_on_no_uuid = os.getenv("HALT_ON_NO_UUID", "false")
+    halt_on_no_uuid = True if halt_on_no_uuid.lower() == "true" else False
+
     xen_poolmaster = collect_poolmaster()
     collector_start_time = time.perf_counter()
 
@@ -173,10 +176,11 @@ def collect_metrics():
                 and "_".join(metric_type.split("_")[0:-1]) in sr_metrics
             ):
                 short_sr = metric_type.split("_")[-1]
-                long_sr = find_full_sr_uuid(short_sr, xen)
-                sr = get_or_set(srs, long_sr, lookup_sr_name_by_uuid, xen)
-                extra_tags["sr"] = sr
-                extra_tags["sr_uuid"] = long_sr
+                long_sr = find_full_sr_uuid(short_sr, xen, halt_on_no_uuid)
+                if(long_sr is not None): ## 
+                    sr = get_or_set(srs, long_sr, lookup_sr_name_by_uuid, xen)
+                    extra_tags["sr"] = sr
+                    extra_tags["sr_uuid"] = long_sr
                 metric_type = "_".join(metric_type.split("_")[0:-1])
 
             if collector_type == "vm" and "vbd_" in metric_type:


### PR DESCRIPTION
I have 6 XCP servers from which I'm exporting metrics. Among these servers, there are 3 where certain shorts_sr are not associated with any host UUID. This issue raises an exception and prevents the export of other functional metrics.

In my case, I require these metrics, but I haven't been able to identify the cause of this problem. The configuration on all 6 XCP servers is the same.

To address this issue, we have introduced a new feature that allows us to determine whether the server should serve metrics even if we don't find some UUIDs. By default, this feature is set to 'false', which prevents the occurrence of exceptions. However, if we set the ENV HALT_ON_NO_UUID variable, it will function as it did before.

In addition to that, I fixed a typo in the other Exception on the function find_full_sr_uuid