### PR TITLE
XEN host up / Add host_ip

### DIFF
--- a/xen-exporter.py
+++ b/xen-exporter.py
@@ -128,6 +128,8 @@ def collect_metrics():
     halt_on_no_uuid = os.getenv("HALT_ON_NO_UUID", "false")
     halt_on_no_uuid = True if halt_on_no_uuid.lower() == "true" else False
 
+    xen_host_up_extra_tags = {}
+
     output = ""
 
     collector_start_time = time.perf_counter()
@@ -229,7 +231,6 @@ def collect_metrics():
         xen_host_up = False
     collector_end_time = time.perf_counter()
     output += f"xen_collector_duration_seconds {collector_end_time - collector_start_time}\n"
-    xen_host_up_extra_tags = {}
     xen_host_up_extra_tags["host_ip"] = xen_host
     tags = {f'{k}="{v}"' for k, v in xen_host_up_extra_tags.items()}
     output += f"xen_host_up{{{', '.join(tags)}}} {1 if xen_host_up == True else 0}\n"


### PR DESCRIPTION
To check if an XCP server is up or not, we can serve a metric xen_host_up with the status of the server, for example if we have a [Errno 113] No route to host exception. By using "xen_host_up," you can receive alerts whenever a host is down.
Here's an example:

![image](https://github.com/MikeDombo/xen-exporter/assets/101902399/9b9a4695-8fad-4ad3-8850-4ee69eb95f7b)

Another option is to create a Grafana Panel that provides a quick overview of the status of XCP hosts.
The values are as follows: 0 for Host Down and 1 for Host Up.

![image](https://github.com/MikeDombo/xen-exporter/assets/101902399/b4ddb935-6283-49b3-b7dd-dbef169a2f13)
![image](https://github.com/MikeDombo/xen-exporter/assets/101902399/67898ff5-8e8a-49ff-b1df-dad0996284e1)

With this setup and the host_ip included in the host metrics, we can provide a link to the panel that filters the results based on the host_ip, allowing for quick access.

Any comments and/or suggestions are welcome. this is a Basic concept by now.